### PR TITLE
Moved definition of default parameters of the constructor to fix g++ compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# README
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+* **AUTHOR**: Andy Goetz
+* **MAIL:** <andy@andygoetz.org>
+* **PROGRAM:** dxf2brd
+
+
+This program converts DXF files to kicad BRD files.  The KICad
+board designer has very primitive support drawing shapes
+accurately. You can use this program to create a complex design in
+a real cad program, like qcad, and import it into a kicad BRD file.
+
+## Compiling
+To use this program, you must have dxflib installed.
+then use the command:
+
+```bash
+g++ dxf2brd.cpp -o dxf2brd -ldxflib
+```
+
+To compile the program.
+
+## Running the program
+To run the program, execute the following command:
+
+```bash
+./dxf2brd some_dxf_file.dxf
+```
+
+It will produce BRD code as its output. to add this code to an existing BRD file, run the following command:
+
+```bash
+./dxf2brd some_dxf_file.dxf >> some_brd_file.brd
+```

--- a/dxf2brd.cpp
+++ b/dxf2brd.cpp
@@ -25,15 +25,15 @@
 // This program converts DXF files to kicad BRD files.  The KICad
 // board designer has very primitive support drawing shapes
 // accurately. You can use this program to create a complex design in
-// a real cad program, like qcad, and import it into a kicad BRD file. 
+// a real cad program, like qcad, and import it into a kicad BRD file.
 
 // Compiling:
-// to use this program, you must have dxflib installed. 
+// to use this program, you must have dxflib installed.
 // then use the command:
-// 
+//
 // g++ dxf2brd.cpp -o dxf2brd -ldxflib
 //
-// To compile the program. 
+// To compile the program.
 
 // running the program:
 // to run the program, execute the following command:
@@ -73,20 +73,21 @@ protected:
 	int xoffset;
 	int yoffset;
 	// layer to draw on in KICAD drawing (28 is board outline)
-	int layer; 
+	int layer;
 	// thickness in tenths of mils of drawing in Kicad
 	int thickness;
 public:
 	// constructor
-	Dxf2BrdFilter(int xoffset, int yoffset, int layer, int thickness);
-	
+	Dxf2BrdFilter(int xoffset =X_OFFSET,  int yoffset =Y_OFFSET,
+				     int layer = LAYER, int thickness = LINE_THICKNESS);
+
 };
 
 
 // lines are the easiest to convert: both kicad and dxf use the same
 // format: pairs of points for the start and end.
 void Dxf2BrdFilter::addLine(const DL_LineData& d) {
-	
+
 
 	int x1 = 0;
 	int x2 = 0;
@@ -96,16 +97,16 @@ void Dxf2BrdFilter::addLine(const DL_LineData& d) {
 	convert(d.x1, d.y1, x1, y1);
 	convert(d.x2, d.y2, x2, y2);
 
-	std::cout << "$DRAWSEGMENT" << std::endl;	
-	std::cout << "Po 0 " << x1 << " " << y1 << " " 
+	std::cout << "$DRAWSEGMENT" << std::endl;
+	std::cout << "Po 0 " << x1 << " " << y1 << " "
 		  << x2 << " " << y2 << " " << thickness << std::endl;
 	std::cout << "De " << layer << " 0 900 0 0" << std::endl;
 	std::cout << "$endDRAWSEGMENT" << std::endl;
-    
+
 }
 // Circles are a bit more complex. Kicad uses two points: one at the
 // center, and one on the circumference to describe a circle, while
-// DXF uses a center and radius. 
+// DXF uses a center and radius.
 
 // not only that, but we need to generate drill holes in the PCB
 // instead of just drawing circles on the PCB in order to do this, we
@@ -113,7 +114,7 @@ void Dxf2BrdFilter::addLine(const DL_LineData& d) {
 // mechanical: that is, it is not plated, and not connected to any
 // net.
 void Dxf2BrdFilter::addCircle(const DL_CircleData& d) {
-	
+
 	int cx = 0;
 	int cy = 0;
 	int xend, yend;
@@ -124,7 +125,7 @@ void Dxf2BrdFilter::addCircle(const DL_CircleData& d) {
 	yend = cy;
 	xend = cx + rad;
 	std::cout << "$MODULE MountingHole" << std::endl;
-	std::cout << "Po " << cx << " " << cy << 
+	std::cout << "Po " << cx << " " << cy <<
 		" 0 15 5052AEE8 5052AC20 ~~" << std::endl;
 	std::cout << "Li MountingHole" << std::endl;
 	std::cout << "Cd Simple Mounting Hole" << std::endl;
@@ -136,7 +137,7 @@ void Dxf2BrdFilter::addCircle(const DL_CircleData& d) {
 	std::cout << "T1 0 1100 400 400 0 100 N I 21 N \"P***\"" << std::endl;
 
 	std::cout << "$PAD" << std::endl;
-	std::cout << "Sh \"\" C " << crad << " " 
+	std::cout << "Sh \"\" C " << crad << " "
 		  << crad << " 0 0 0" << std::endl;
 	std::cout << "Dr " << rad << " 0 0" << std::endl;
 	std::cout << "At HOLE N 00E0FFFF" << std::endl;
@@ -152,7 +153,7 @@ void Dxf2BrdFilter::addCircle(const DL_CircleData& d) {
 	std::cout << "De 24 0 900 0 0" << std::endl;
 	std::cout << "$EndDRAWSEGMENT" << std::endl;
 
-	
+
 }
 
 // This is the most complex conversion. Kicad only allows arcs of 90
@@ -164,7 +165,7 @@ void Dxf2BrdFilter::addCircle(const DL_CircleData& d) {
 // defined by moving -90 degrees from the start point.
 
 // in addition, to simplify the logic: this routine only supports 180
-// arcs that are located at 90 degree angles. 
+// arcs that are located at 90 degree angles.
 void Dxf2BrdFilter::addArc(const DL_ArcData& d) {
 
 	int xstart = 0;
@@ -184,8 +185,8 @@ void Dxf2BrdFilter::addArc(const DL_ArcData& d) {
 		std::cerr << "Arc not 180 degrees long!" << std::endl;
 		return;
 	}
-		
-	
+
+
 	// in order to draw the semicircles, we split the single DXF
 	// arc into two 90 degree kicad arcs. In order to draw this
 	// correctly, we need to calculate the end points for these
@@ -205,12 +206,12 @@ void Dxf2BrdFilter::addArc(const DL_ArcData& d) {
 	} else {
 		std::cerr << "weird angles: " << a1 << " " << a2 << std::endl;
 		return;
-	}	
+	}
 	convert(d.cx, d.cy, xstart, ystart);
-		
+
 	convertangle(d.cx, d.cy, d.radius, ka1, xend, yend);
 	std::cout << "$DRAWSEGMENT" << std::endl;
-	std::cout << "Po 2 " << xstart << " " << ystart << " " 
+	std::cout << "Po 2 " << xstart << " " << ystart << " "
 		  << xend << " " << yend << " " << thickness << std::endl;
 	std::cout << "De " << layer << " 0 900 0 0" << std::endl;
 	std::cout << "$endDRAWSEGMENT" << std::endl;
@@ -219,7 +220,7 @@ void Dxf2BrdFilter::addArc(const DL_ArcData& d) {
 
 	convertangle(d.cx, d.cy, d.radius, ka2, xend, yend);
 	std::cout << "$DRAWSEGMENT" << std::endl;
-	std::cout << "Po 2 " << xstart << " " << ystart << " " 
+	std::cout << "Po 2 " << xstart << " " << ystart << " "
 		  << xend << " " << yend << " " << thickness << std::endl;
 	std::cout << "De " << layer << " 0 900 0 0" << std::endl;
 	std::cout << "$endDRAWSEGMENT" << std::endl;
@@ -232,8 +233,8 @@ void Dxf2BrdFilter::addArc(const DL_ArcData& d) {
 }
 
 // constructor
-Dxf2BrdFilter::Dxf2BrdFilter(int xoffset =X_OFFSET,  int yoffset =Y_OFFSET, 
-			     int layer = LAYER, int thickness = LINE_THICKNESS) : 
+Dxf2BrdFilter::Dxf2BrdFilter(int xoffset,  int yoffset,
+			     int layer, int thickness) : 
 	xoffset(xoffset), yoffset(yoffset), layer(layer), thickness(thickness) {}
 
 void Dxf2BrdFilter::convert(double xin, double yin, int &xout, int &yout)
@@ -244,7 +245,7 @@ void Dxf2BrdFilter::convert(double xin, double yin, int &xout, int &yout)
 
 }
 
-void Dxf2BrdFilter::convertangle(double xin, double yin, 
+void Dxf2BrdFilter::convertangle(double xin, double yin,
 				 double radius, double angle, int &xout, int &yout)
 {
 	convert(xin, yin, xout, yout);
@@ -265,7 +266,7 @@ void Dxf2BrdFilter::convertangle(double xin, double yin,
 	default:
 		std::cerr << "invalid angle: " << angle << std::endl;
 	}
-	
+
 }
 
 int main(int argc, char ** argv)
@@ -274,10 +275,10 @@ int main(int argc, char ** argv)
 		return -1;
 	Dxf2BrdFilter f;
 	DL_Dxf* dxf = new DL_Dxf();
-	
+
 	if (!dxf->in(argv[1], &f)) {
 		std::cerr << "drawing could not be opened.\n";
 	}
-	delete dxf; 
+	delete dxf;
 	return 0;
 }


### PR DESCRIPTION
Moved definition of default parameters of the constructor from the function definition to the declaration to fix compilation errors on newer versions of g++.

For more information, a similar issue is documented here: http://stackoverflow.com/questions/18313509/default-argument-gcc-vs-clang

Here's the error message that newer versions of g++ outputs without this change:

$gcc dxf2brd.cpp -o dxf2brd -ldxflib
dxf2brd.cpp:235:34: error: addition of default argument on
      redeclaration makes this constructor a default
      constructor
Dxf2BrdFilter::Dxf2BrdFilter(int xoffset =X_OFFSET...
                                 ^        ~~~~~~~~
dxf2brd.cpp:81:2: note: previous declaration is here
        Dxf2BrdFilter(int xoffset, int yoffset, in...
        ^
1 error generated.

With this change, it now compiles as normal!
Thanks for the awesome software!
